### PR TITLE
Added custom encoding support

### DIFF
--- a/src/com/bgp/codec/DecodingMethod.java
+++ b/src/com/bgp/codec/DecodingMethod.java
@@ -1,0 +1,11 @@
+package com.bgp.codec;
+
+/**
+ * Interface for custom decoding method callback.
+ * 
+ * @author Giuseppe
+ *
+ */
+public interface DecodingMethod {
+	public byte[] decode(String str);
+}

--- a/src/com/bgp/codec/EncodingMethod.java
+++ b/src/com/bgp/codec/EncodingMethod.java
@@ -1,0 +1,12 @@
+package com.bgp.codec;
+
+
+/**
+ * Interface for custom encoding method callback.
+ * 
+ * @author Giuseppe Petrosino
+ *
+ */
+public interface EncodingMethod {
+	public String encodeAsString(byte[] bytes);
+}

--- a/src/com/bgp/decryption/Decrypt.java
+++ b/src/com/bgp/decryption/Decrypt.java
@@ -8,6 +8,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base64;
 
+import com.bgp.codec.DecodingMethod;
 import com.bgp.compression.Gzip;
 
 /**
@@ -21,6 +22,7 @@ public class Decrypt {
     private PrivateKey privateKey;
     private SecretKey cryptedSessionKey; 
     private SecretKey sessionKey;
+    private DecodingMethod customDecoding = null;
     
     /**
      * Ctor. Decrypt the session key with the private key
@@ -41,7 +43,9 @@ public class Decrypt {
      * @return decrypted string
      */
     public String decrypt(String cipherText) throws Exception {
-        byte[] decodedCipherText = new Base64().decode(cipherText);
+        byte[] decodedCipherText;
+        if(customDecoding == null) decodedCipherText = new Base64().decode(cipherText);
+        else decodedCipherText = customDecoding.decode(cipherText);
         
         // decrypt data using the original session key
         Cipher c = Cipher.getInstance("AES");
@@ -66,5 +70,16 @@ public class Decrypt {
 
         SecretKey originalSessionKey = new SecretKeySpec(SK, 0, SK.length, "AES");
         return originalSessionKey;
+    }
+    
+    
+    /**
+     * Sets a custom decoding method to be used instead of the
+     * default from Apache Common Codec lib.
+     * 
+     * @param method the method
+     */
+    public void setCustomDecoding(DecodingMethod method){
+    	this.customDecoding = method;
     }
 }

--- a/src/com/bgp/encryption/Encrypt.java
+++ b/src/com/bgp/encryption/Encrypt.java
@@ -14,6 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base64;
 
+import com.bgp.codec.EncodingMethod;
 import com.bgp.compression.Gzip;
 
 /**
@@ -27,6 +28,7 @@ public class Encrypt {
     private SecretKey sessionKey;
     private SecretKey encryptedSessionKey;
     private PublicKey publicKey;
+    private EncodingMethod customEncoding = null;
 
     /**
      * Ctor. Generate a session key, then encrypt the generated session key with
@@ -77,7 +79,10 @@ public class Encrypt {
         byte[] encodedData = c.doFinal(compressedData);
 
         // encode the encrypted data as a string
-        String cipherText = new Base64().encodeAsString(encodedData);
+        String cipherText;
+        if(customEncoding == null) cipherText = new Base64().encodeAsString(encodedData);
+        else cipherText = customEncoding.encodeAsString(encodedData);
+        
         return cipherText;
     }
 
@@ -108,5 +113,15 @@ public class Encrypt {
      */
     public SecretKey getEncryptedSessionKey() {
         return encryptedSessionKey;
+    }
+    
+    /**
+     * Sets a custom encoding method to be used instead of the
+     * default from Apache Common Codec lib.
+     * 
+     * @param method the method
+     */
+    public void setCustomEncoding(EncodingMethod method){
+    	this.customEncoding = method;
     }
 }


### PR DESCRIPTION
With this changes, from now on setCustomDecoding() - in Decrypt - and setCustomEncoding() - in Encrypt - can be used to define custom encoding/decoding methods that will be used instead of the default methods provided by Apache Common Codec library.
